### PR TITLE
await innecesario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 .env
 test-report.html
 coverage
+yarn*

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,8 @@ import http from 'http';
 
 const host = process.env.HOST || '0.0.0.0';
 const port = process.env.PORT || 3001;
-const startServer = async () => {
-  const app = await createServer();
+const startServer = () => {
+  const app = createServer();
   const server = http.createServer(app);
   server.listen({host, port}, () => {
     const address = server.address() as AddressInfo;


### PR DESCRIPTION
la funcion createServer no retorna un promise, no es asyncrona, por lo cual no es necesario esperar a que termine de ejecutarse(el await es innecesario y dado que es el unico lugar donde se usa await la funcion superir a este codigo no necesita ser asyncrona)